### PR TITLE
ffmped path property 

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ module.exports = async (opts) => {
     timestamps,
     offsets,
     fps,
-    numFrames
+    numFrames,
+    ffmpegPath
   } = opts
 
   if (!input) throw new Error('missing required input')
@@ -26,6 +27,9 @@ module.exports = async (opts) => {
 
   const outputPath = path.parse(output)
 
+  if (typeof ffmpegPath !== 'undefined' && ffmpegPath !== '') {
+    ffmpeg.setFfmpegPath(ffmpegPath)
+  }
   const cmd = ffmpeg(input)
     .on('start', (cmd) => log({ cmd }))
 

--- a/index.js
+++ b/index.js
@@ -27,9 +27,10 @@ module.exports = async (opts) => {
 
   const outputPath = path.parse(output)
 
-  if (typeof ffmpegPath !== 'undefined' && ffmpegPath !== '') {
+  if (ffmpegPath) {
     ffmpeg.setFfmpegPath(ffmpegPath)
   }
+  
   const cmd = ffmpeg(input)
     .on('start', (cmd) => log({ cmd }))
 

--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Optional function to log the underlying ffmpeg command (like `console.log`).
 
 Type: `String`
 
-Specify a path for ffmpeg binaries. Use this property to set a different path for ffmpeg binaries.
+Specify a path for the ffmpeg binary.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -107,6 +107,12 @@ Default: `noop`
 
 Optional function to log the underlying ffmpeg command (like `console.log`).
 
+##### ffmpegPath
+
+Type: `String`
+
+Specify a path for ffmpeg binaries. Use this property to set a different path for ffmpeg binaries.
+
 ## Related
 
 - [ffmpeg-extract-frame](https://github.com/transitive-bullshit/ffmpeg-extract-frame) - Extracts a single frame from a video.


### PR DESCRIPTION
Implementing a new property to set the ffmpeg path to the binaries. This new property could be used if you want to include ffmpeg binaries in your app.

In my case, I'm using `ffmpeg-extract-frames` to take frames from videos. But because I'm using the package in a lambda function, I have to implement a workaround to set the ffmpeg path because I'm using `@ffmpeg-installer/ffmpeg` for the binaries.