### PR TITLE
Adds forceSARRatio option to add 'scale=iw*sar:ih' to video-filter list.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "ffmpeg-extract-frames",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Extracts frames from a video.",
   "main": "index.js",
   "repository": "transitive-bullshit/ffmpeg-extract-frames",
   "author": "Travis Fischer <travis@automagical.ai>",
+  "contributors": [
+    {
+      "name" : "Adam Hunter"
+      , "url" : "https://github.com/adamrhunter"
+    }
+  ],
   "license": "MIT",
   "reveal": true,
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@
 
 [![NPM](https://img.shields.io/npm/v/ffmpeg-extract-frames.svg)](https://www.npmjs.com/package/ffmpeg-extract-frames) [![Build Status](https://travis-ci.com/transitive-bullshit/ffmpeg-extract-frames.svg?branch=master)](https://travis-ci.com/transitive-bullshit/ffmpeg-extract-frames) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
+> This is a fork from the orginal (which seemed to have stopped accpeting PRs).  I've added some additional parameters/options to pass into the process (and fixed some bugs with frame offsets)
+
 ## Install
 
 ```bash
@@ -119,6 +121,18 @@ Type: `Boolean`
 Default: false
 
 Force ffmpeg to use `scale=iw*sar:ih` video filter to use SampleAspectRatio as aspect ratio for thumbnail images.
+
+##### startOffset
+
+Type: `Number`
+
+Start the frame extraction from the given offset (in seconds)
+
+##### duration
+
+Type: `Number`
+
+Run the extraction for only the given duration (in seconds)
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,13 @@ Type: `String`
 
 Specify a path for the ffmpeg binary.
 
+##### forceSARRatio
+
+Type: `Boolean`
+Default: false
+
+Force ffmpeg to use `scale=iw*sar:ih` video filter to use SampleAspectRatio as aspect ratio for thumbnail images.
+
 ## Related
 
 - [ffmpeg-extract-frame](https://github.com/transitive-bullshit/ffmpeg-extract-frame) - Extracts a single frame from a video.


### PR DESCRIPTION
For some older mpeg2 videos / NTSC content I've found that the thumbnails generated are not at the correct aspect ratio.  This option allows the user to try and force the aspect ration based on the SAR that is determined by ffmpeg.